### PR TITLE
Stress-test enabling the script

### DIFF
--- a/bot-scripts/python/p1-protect-script-native.py
+++ b/bot-scripts/python/p1-protect-script-native.py
@@ -4,19 +4,27 @@ import requests
 import time
 import json
 import os
+from random import randint
 # import UserAgent generator
 from fake_useragent import UserAgent
 # Import Selenium components
 from selenium import webdriver
-from selenium.webdriver.chrome.service import Service as ChromeService
-from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
 
 options = Options()
+
+time.sleep(randint(1,5))
+
+# URL of where to run this bot - If not `localhost`, it's injected via STARTURL environment variable 
+# Note: If using Docker, the image can't be running on `locahost` - deploy into k8s \ Azure \ AWS \ etc
+startUrl = os.getenv('STARTURL')
+if not startUrl:
+    startUrl = "http://localhost:3000/loginForm.html"
+
+print("Connecting to: ", startUrl)
 
 # Get new User-Agent
 ua = UserAgent()
@@ -38,8 +46,6 @@ browser = webdriver.Chrome(options=options)
 
 # Hide that Selenium is being used
 browser.execute_script("Object.defineProperty(navigator, 'webdriver', {get: () => undefined})")
-
-# Chrome Only
 browser.execute_cdp_cmd('Network.setUserAgentOverride', {"userAgent": userAgent})
 
 # Get some random user data for Registration
@@ -48,15 +54,7 @@ userDetails = getUser.json()
 userEmail = userDetails['results'][0]['email']
 userPass = userDetails['results'][0]['login']['password']
 
-wait = WebDriverWait(browser, 15)
-
-# URL of where to run this bot - If not `localhost`, it's injected via STARTURL environment variable 
-# Note: If using Docker, the image can't be running on `locahost` - deploy into k8s \ Azure \ AWS \ etc
-startUrl = os.getenv('STARTURL')
-if not startUrl:
-    startUrl = "http://localhost:3000/loginForm.html"
-
-print("Connecting to: ", startUrl)
+wait = WebDriverWait(browser, 20)
 
 # Get the web page and start the bot functions
 browser.get(startUrl)


### PR DESCRIPTION
Moving the Chrome driver into the script folder instead of using Webdriver.Manager to get it.